### PR TITLE
Fix deletion of schedule with roll call entries

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using CourseManagerment.Models;
 using Microsoft.EntityFrameworkCore;
+using System.Linq;
 
 namespace CourseManagerment
 {
@@ -107,9 +108,15 @@ namespace CourseManagerment
             {
                 if (MessageBox.Show("Are you sure you want to delete?", "Confirm", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
                 {
-                    var schedule = context.CourseSchedules.Find(selected.TeachingScheduleId);
+                    var schedule = context.CourseSchedules
+                        .Include(s => s.RollCallBooks)
+                        .FirstOrDefault(s => s.TeachingScheduleId == selected.TeachingScheduleId);
                     if (schedule != null)
                     {
+                        if (schedule.RollCallBooks.Any())
+                        {
+                            context.RollCallBooks.RemoveRange(schedule.RollCallBooks);
+                        }
                         context.CourseSchedules.Remove(schedule);
                         context.SaveChanges();
                         if (cbCourse.SelectedValue is int cId)


### PR DESCRIPTION
## Summary
- cleanly remove dependent `RollCallBook` rows when deleting a schedule
- add missing `System.Linq` using directive

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685cc6df2c548333941c3888fcaec43a