### PR TITLE
Show teaching id in edit window

### DIFF
--- a/EditSchedule.xaml
+++ b/EditSchedule.xaml
@@ -14,24 +14,27 @@
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"></ColumnDefinition>
             <ColumnDefinition Width="*"></ColumnDefinition>
         </Grid.ColumnDefinitions>
-        <Label Grid.Row="0" Grid.Column="0" Content="CourseId:" Margin="5"></Label>
-        <ComboBox Grid.Row="0" Grid.Column="1" Name="cbCourseId" DisplayMemberPath="CourseCode" 
+        <Label Grid.Row="0" Grid.Column="0" Content="TeachingId:" Margin="5"></Label>
+        <TextBox Grid.Row="0" Grid.Column="1" Name="txtTeachingId" Margin="5" IsReadOnly="True"></TextBox>
+        <Label Grid.Row="1" Grid.Column="0" Content="CourseId:" Margin="5"></Label>
+        <ComboBox Grid.Row="1" Grid.Column="1" Name="cbCourseId" DisplayMemberPath="CourseCode"
                   SelectedValuePath="CourseId" Margin="5"></ComboBox>
-        <Label Grid.Row="1" Grid.Column="0" Content="TeachingDate:" Margin="5"></Label>
-        <DatePicker Grid.Row="1" Grid.Column="1" Name="Picker" Margin="5"></DatePicker>
-        <Label Grid.Row="2" Grid.Column="0" Content="Slot:" Margin="5"></Label>
-        <TextBox Grid.Row="2" Grid.Column="1" Name="Slot" Margin="5"></TextBox>
-        <Label Grid.Row="3" Grid.Column="0" Content="RoomId:" Margin="5"></Label>
-        <ComboBox Grid.Row="3" Grid.Column="1" Name="cbRoomId" DisplayMemberPath="RoomCode" 
+        <Label Grid.Row="2" Grid.Column="0" Content="TeachingDate:" Margin="5"></Label>
+        <DatePicker Grid.Row="2" Grid.Column="1" Name="Picker" Margin="5"></DatePicker>
+        <Label Grid.Row="3" Grid.Column="0" Content="Slot:" Margin="5"></Label>
+        <TextBox Grid.Row="3" Grid.Column="1" Name="Slot" Margin="5"></TextBox>
+        <Label Grid.Row="4" Grid.Column="0" Content="RoomId:" Margin="5"></Label>
+        <ComboBox Grid.Row="4" Grid.Column="1" Name="cbRoomId" DisplayMemberPath="RoomCode"
            SelectedValuePath="RoomId" Margin="5"></ComboBox>
-        <Label Grid.Row="4" Grid.Column="0" Content="Description:" Margin="5"></Label>
-        <TextBox Grid.Row="4" Grid.Column="1" Name="Description" Margin="5"></TextBox>
-        <Button Grid.Row="5" Grid.Column="1" Name="saveEdit" Content="Save Edit" 
+        <Label Grid.Row="5" Grid.Column="0" Content="Description:" Margin="5"></Label>
+        <TextBox Grid.Row="5" Grid.Column="1" Name="Description" Margin="5"></TextBox>
+        <Button Grid.Row="6" Grid.Column="1" Name="saveEdit" Content="Save Edit"
                 Width="80" HorizontalAlignment="Right" Margin="5" Click="saveEdit_Click"></Button>
 
     </Grid>

--- a/EditSchedule.xaml.cs
+++ b/EditSchedule.xaml.cs
@@ -27,8 +27,8 @@ namespace CourseManagerment
             InitializeComponent();
             editSchedule = schedule;
             LoadcbData();
+            txtTeachingId.Text = schedule.TeachingScheduleId.ToString();
             cbCourseId.SelectedValue = schedule.CourseId;
-            cbCourseId.IsEnabled = false;
             Picker.SelectedDate = schedule.TeachingDate;
             Slot.Text = schedule.Slot?.ToString();
             cbRoomId.SelectedValue = schedule.RoomId;


### PR DESCRIPTION
## Summary
- show `TeachingId` on the edit schedule window but make it read-only
- allow editing of `CourseId` by removing previous restriction

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685ce4e244bc8333abc5f934cb12e54d