### PR TITLE
Add home UI and student management window

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:CourseManagerment"
-             StartupUri="MainWindow.xaml">
+             StartupUri="HomeWindow.xaml">
     <Application.Resources>
          
     </Application.Resources>

--- a/HomeWindow.xaml
+++ b/HomeWindow.xaml
@@ -1,0 +1,9 @@
+<Window x:Class="CourseManagerment.HomeWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Home" Height="200" Width="300">
+    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Button Content="Schedule Management" Width="200" Margin="5" Click="Schedule_Click"/>
+        <Button Content="Student Management" Width="200" Margin="5" Click="Student_Click"/>
+    </StackPanel>
+</Window>

--- a/HomeWindow.xaml.cs
+++ b/HomeWindow.xaml.cs
@@ -1,0 +1,24 @@
+using System.Windows;
+
+namespace CourseManagerment
+{
+    public partial class HomeWindow : Window
+    {
+        public HomeWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void Schedule_Click(object sender, RoutedEventArgs e)
+        {
+            var win = new MainWindow();
+            win.ShowDialog();
+        }
+
+        private void Student_Click(object sender, RoutedEventArgs e)
+        {
+            var win = new StudentManagement();
+            win.ShowDialog();
+        }
+    }
+}

--- a/StudentManagement.xaml
+++ b/StudentManagement.xaml
@@ -1,0 +1,52 @@
+<Window x:Class="CourseManagerment.StudentManagement"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Student Management" Height="500" Width="800">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <TextBox Name="txtSearch" Width="200" Margin="0,0,0,5" TextChanged="txtSearch_TextChanged" />
+        <DataGrid Grid.Row="1" Name="dgStudents" AutoGenerateColumns="False" Margin="0,0,0,5" SelectionChanged="dgStudents_SelectionChanged">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="StudentId" Binding="{Binding StudentId}" />
+                <DataGridTextColumn Header="Roll" Binding="{Binding Roll}" />
+                <DataGridTextColumn Header="FirstName" Binding="{Binding FirstName}" />
+                <DataGridTextColumn Header="MidName" Binding="{Binding MidName}" />
+                <DataGridTextColumn Header="LastName" Binding="{Binding LastName}" />
+            </DataGrid.Columns>
+        </DataGrid>
+        <Grid Grid.Row="2">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Label Grid.Row="0" Grid.Column="0" Content="StudentId:" Margin="5" />
+            <TextBox Grid.Row="0" Grid.Column="1" Name="txtStudentId" Margin="5" />
+            <Label Grid.Row="1" Grid.Column="0" Content="Roll:" Margin="5" />
+            <TextBox Grid.Row="1" Grid.Column="1" Name="txtRoll" Margin="5" />
+            <Label Grid.Row="2" Grid.Column="0" Content="FirstName:" Margin="5" />
+            <TextBox Grid.Row="2" Grid.Column="1" Name="txtFirstName" Margin="5" />
+            <Label Grid.Row="3" Grid.Column="0" Content="MidName:" Margin="5" />
+            <TextBox Grid.Row="3" Grid.Column="1" Name="txtMidName" Margin="5" />
+            <Label Grid.Row="4" Grid.Column="0" Content="LastName:" Margin="5" />
+            <TextBox Grid.Row="4" Grid.Column="1" Name="txtLastName" Margin="5" />
+            <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Left">
+                <Button Name="btnAdd" Content="Add" Width="80" Margin="5" Click="btnAdd_Click" />
+                <Button Name="btnEdit" Content="Edit" Width="80" Margin="5" Click="btnEdit_Click" />
+                <Button Name="btnDelete" Content="Delete" Width="80" Margin="5" Click="btnDelete_Click" />
+                <Button Name="btnReset" Content="Reset" Width="80" Margin="5" Click="btnReset_Click" />
+            </StackPanel>
+        </Grid>
+    </Grid>
+</Window>

--- a/StudentManagement.xaml.cs
+++ b/StudentManagement.xaml.cs
@@ -1,0 +1,145 @@
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using CourseManagerment.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CourseManagerment
+{
+    public partial class StudentManagement : Window
+    {
+        ApContext context = new ApContext();
+        public StudentManagement()
+        {
+            InitializeComponent();
+            LoadData();
+        }
+
+        private void LoadData(string? search = null)
+        {
+            var query = context.Students.AsQueryable();
+            if (!string.IsNullOrWhiteSpace(search))
+            {
+                query = query.Where(s =>
+                    (s.FirstName ?? "").Contains(search) ||
+                    (s.MidName ?? "").Contains(search) ||
+                    (s.LastName ?? "").Contains(search));
+            }
+            dgStudents.ItemsSource = query.ToList();
+        }
+
+        private void txtSearch_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            LoadData(txtSearch.Text);
+        }
+
+        private void dgStudents_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (dgStudents.SelectedItem is Student student)
+            {
+                txtStudentId.Text = student.StudentId.ToString();
+                txtRoll.Text = student.Roll;
+                txtFirstName.Text = student.FirstName;
+                txtMidName.Text = student.MidName;
+                txtLastName.Text = student.LastName;
+                txtStudentId.IsEnabled = false;
+            }
+        }
+
+        private void btnAdd_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var student = new Student
+                {
+                    StudentId = int.Parse(txtStudentId.Text),
+                    Roll = txtRoll.Text,
+                    FirstName = txtFirstName.Text,
+                    MidName = txtMidName.Text,
+                    LastName = txtLastName.Text
+                };
+                context.Students.Add(student);
+                context.SaveChanges();
+                LoadData(txtSearch.Text);
+                ResetForm();
+            }
+            catch (System.Exception ex)
+            {
+                MessageBox.Show("Error " + ex.Message);
+            }
+        }
+
+        private void btnEdit_Click(object sender, RoutedEventArgs e)
+        {
+            if (dgStudents.SelectedItem is Student selected)
+            {
+                var student = context.Students.Find(selected.StudentId);
+                if (student != null)
+                {
+                    student.Roll = txtRoll.Text;
+                    student.FirstName = txtFirstName.Text;
+                    student.MidName = txtMidName.Text;
+                    student.LastName = txtLastName.Text;
+                    context.SaveChanges();
+                    LoadData(txtSearch.Text);
+                    ResetForm();
+                }
+            }
+            else
+            {
+                MessageBox.Show("Please select a student to edit");
+            }
+        }
+
+        private void btnDelete_Click(object sender, RoutedEventArgs e)
+        {
+            if (dgStudents.SelectedItem is Student selected)
+            {
+                if (MessageBox.Show("Are you sure you want to delete?", "Confirm", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
+                {
+                    var student = context.Students
+                        .Include(s => s.RollCallBooks)
+                        .Include(s => s.Courses)
+                        .FirstOrDefault(s => s.StudentId == selected.StudentId);
+                    if (student != null)
+                    {
+                        if (student.RollCallBooks.Any())
+                        {
+                            context.RollCallBooks.RemoveRange(student.RollCallBooks);
+                        }
+                        if (student.Courses.Any())
+                        {
+                            student.Courses.Clear();
+                        }
+                        context.Students.Remove(student);
+                        context.SaveChanges();
+                        LoadData(txtSearch.Text);
+                        ResetForm();
+                    }
+                }
+            }
+            else
+            {
+                MessageBox.Show("Please select a student to delete");
+            }
+        }
+
+        private void btnReset_Click(object sender, RoutedEventArgs e)
+        {
+            ResetForm();
+            txtSearch.Text = string.Empty;
+            LoadData();
+        }
+
+        private void ResetForm()
+        {
+            txtStudentId.Text = string.Empty;
+            txtRoll.Text = string.Empty;
+            txtFirstName.Text = string.Empty;
+            txtMidName.Text = string.Empty;
+            txtLastName.Text = string.Empty;
+            dgStudents.SelectedItem = null;
+            txtStudentId.IsEnabled = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `HomeWindow` with buttons to launch schedules or students
- implement `StudentManagement` window with dynamic search and CRUD features
- disallow editing StudentId once an entry is selected
- set the app startup to the new home window

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685cf346669c8333b1f1de1e73518638